### PR TITLE
chore: add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+tab_width = 4
+trim_trailing_whitespace = true


### PR DESCRIPTION
Adds an initial `.editorconfig` file.

The `.editorconfig` file is used to configure IDE or code editor settings according to a project's coding style.